### PR TITLE
bridge: Lock Alpine version to 3.18

### DIFF
--- a/bridge/img-src/Dockerfile
+++ b/bridge/img-src/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.18
 
 RUN apk add -U --no-cache \
     iptables \


### PR DESCRIPTION

**- What I did**
Locked Alpine version to 3.18 because latest 3.19 does not anymore contain `/sbin/iptables-legacy` and build was failing with it.

**- How I did it**

**- How to verify it**

**- Description for the changelog**